### PR TITLE
fix "http: read on closed response body"

### DIFF
--- a/pkg/net/http/resty.go
+++ b/pkg/net/http/resty.go
@@ -39,6 +39,7 @@ func (r *restyClient) Get(ctx context.Context, url string, params map[string]str
 	}
 
 	resp, err := client.R().
+		//SetDoNotParseResponse(true).
 		SetContext(ctx).
 		SetHeaders(map[string]string{
 			"Content-Type": contentTypeJSON,
@@ -72,6 +73,7 @@ func (r *restyClient) Post(ctx context.Context, url string, data []byte, duratio
 	}
 
 	cr := client.R().
+		SetDoNotParseResponse(true).
 		SetContext(ctx).
 		SetBody(string(data)).
 		SetHeaders(map[string]string{

--- a/pkg/net/http/resty.go
+++ b/pkg/net/http/resty.go
@@ -39,7 +39,7 @@ func (r *restyClient) Get(ctx context.Context, url string, params map[string]str
 	}
 
 	resp, err := client.R().
-		//SetDoNotParseResponse(true).
+		SetDoNotParseResponse(true).
 		SetContext(ctx).
 		SetHeaders(map[string]string{
 			"Content-Type": contentTypeJSON,


### PR DESCRIPTION
fix "http: read on closed response body"
ref:https://github.com/go-resty/resty/issues/369
ref:https://pkg.go.dev/github.com/go-resty/resty/v2#Request.SetDoNotParseResponse