### PR TITLE
日志记录模块优化

### DIFF
--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -20,6 +20,9 @@ type Fields map[string]interface{}
 
 // Logger is a contract for the logger
 type Logger interface {
+	Debug(args ...interface{})
+	Debugf(format string, args ...interface{})
+
 	Info(args ...interface{})
 	Infof(format string, args ...interface{})
 
@@ -88,6 +91,11 @@ func WithContext(ctx context.Context) Logger {
 	return log
 }
 
+// Debug logger
+func Debug(args ...interface{}) {
+	log.Debug(args...)
+}
+
 // Info logger
 func Info(args ...interface{}) {
 	log.Info(args...)
@@ -101,6 +109,11 @@ func Warn(args ...interface{}) {
 // Error logger
 func Error(args ...interface{}) {
 	log.Error(args...)
+}
+
+// Debugf logger
+func Debugf(format string, args ...interface{}) {
+	log.Debugf(format, args...)
 }
 
 // Infof logger

--- a/pkg/log/span_logger.go
+++ b/pkg/log/span_logger.go
@@ -18,6 +18,20 @@ type spanLogger struct {
 	spanFields []zapcore.Field
 }
 
+func (sl spanLogger) Debug(args ...interface{}) {
+	msg := fmt.Sprint(args...)
+	var fields []zap.Field
+	sl.logToSpan("debug", msg)
+	sl.logger.Debug(msg, append(sl.spanFields, fields...)...)
+}
+
+func (sl spanLogger) Debugf(format string, args ...interface{}) {
+	msg := fmt.Sprintf(format, args...)
+	var fields []zap.Field
+	sl.logToSpan("Debugf", msg)
+	sl.logger.Debug(msg, append(sl.spanFields, fields...)...)
+}
+
 func (sl spanLogger) Info(args ...interface{}) {
 	msg := fmt.Sprint(args...)
 	var fields []zap.Field


### PR DESCRIPTION
本次 PR 是针对 pkg/log 模块的优化，包含以下两个内容：

1. 增加了 Debug 级别日志的支持。
2. 修复了直接通过 `log.GetLogger` 或 `log.WithFields` 等方法使用 Logger 对象记录日志时，caller 不正确的问题。

caller 不正确的原因：
使用 Logger 对象记录日志与使用全局方法（如 `log.Info`）记录日志的调用层级不同，但是 `buildLogger` 方法在创建 zap.Logger 时强制将跳过层级设置为 2，导致使用 Logger 对象记录日志时会多跳一层，造成日志输出时 caller 不正确。

https://github.com/go-eagle/eagle/blob/81272e9937ca42a1179de3d0f5ab208a962a1225/pkg/log/zap.go#L134-L139

正确的做法应该是：
使用 Logger 对象记录日志时，跳一层
```
Logger.Info -> zap.Logger.Info
```

使用全局方法记录日志时，跳两层
```
log.Info -> Logger.Info -> zap.Logger.Info
```