### PR TITLE
chore: removed volume not is used in master

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,4 +80,3 @@ networks:
 volumes:
   mysql_data:
   redis_data:
-  mongodb_data:


### PR DESCRIPTION
volume mongodb_data only used in develop