### PR TITLE
fix: do not return redis.ErrRedisNotFound error in GetNameCache

### DIFF
--- a/cmd/eagle/internal/cache/add/template.go
+++ b/cmd/eagle/internal/cache/add/template.go
@@ -77,7 +77,7 @@ func (c *{{.LcName}}Cache) Set{{.Name}}Cache(ctx context.Context, id int64, data
 func (c *{{.LcName}}Cache) Get{{.Name}}Cache(ctx context.Context, id int64) (data *model.{{.Name}}Model, err error) {
 	cacheKey := c.Get{{.Name}}CacheKey(id)
 	err = c.cache.Get(ctx, cacheKey, &data)
-	if err != nil {
+	if err != nil &&  && err != redis.ErrRedisNotFound {
 		log.WithContext(ctx).Warnf("get err from redis, err: %+v", err)
 		return nil, err
 	}


### PR DESCRIPTION
It it really not necessary to return redis.ErrRedisNotFound to service layer. nil return is enough for caller to decide to get from  db next step.