### PR TITLE
完善Error类的接口, 以修复gin.pb无法解析业务内错误的问题

### DIFF
--- a/pkg/errcode/error.go
+++ b/pkg/errcode/error.go
@@ -31,6 +31,11 @@ func (e Error) Error() string {
 	return fmt.Sprintf("code: %d, msg: %s", e.Code(), e.Msg())
 }
 
+// HTTPCode return http code
+func (e *Error) HTTPCode() int {
+	return ToHTTPStatusCode(e.code)
+}
+
 // Code return error code
 func (e *Error) Code() int {
 	return e.code
@@ -39,6 +44,11 @@ func (e *Error) Code() int {
 // Msg return error msg
 func (e *Error) Msg() string {
 	return e.msg
+}
+
+// Message return error msg
+func (e *Error) Message() string {
+	return fmt.Sprintf("%s %v", e.msg, e.details)
 }
 
 // Msgf format error string


### PR DESCRIPTION
errcode.Error类新增两个接口实现：
HTTPCode() int
Message() string

以适配gin.pb.go中的iCode接口
```
	type iCode interface {
		HTTPCode() int
		Message() string
		Code() int
	}
        var c iCode
	if errors.As(err, &c) {
		status = c.HTTPCode()
		code = c.Code()
		msg = c.Message()
	}
```