### PR TITLE
Update client.go

### DIFF
--- a/pkg/client/httpclient/client.go
+++ b/pkg/client/httpclient/client.go
@@ -85,9 +85,6 @@ func doRequest(ctx context.Context, method, url string, payload []byte, opt *opt
 		req.Header.Set(key, value[0])
 	}
 
-	ctx, span := tracer.Start(req.Context(), fmt.Sprintf("HTTP %s", method))
-	defer span.End()
-
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, errors.Wrapf(err, "[httpClient] do request from [%s %s] err", method, url)


### PR DESCRIPTION
remove unnecessary span/清除不必要的span

在启用otelhttp.NewTransport之后，内部实现会新建该请求的span，不需要手动开启span
ps. 结束span有两种方式：一种请求有err，内部结束span；还有一种请求有正常返回，通过resp.Body.Close()结束span