### PR TITLE
chore: new project by adding branch name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v1.8.2
 - feat: support PostgreSQL
 - feat: support config multiple databases
+- chore(cli): generate project by adding branch name
 
 ## v1.8.1
 - fix: GitHub workflow badge URL

--- a/cmd/eagle/internal/base/repo_test.go
+++ b/cmd/eagle/internal/base/repo_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestRepo(t *testing.T) {
-	r := NewRepo("https://github.com/go-eagle/eagle-layout.git")
+	r := NewRepo("https://github.com/go-eagle/eagle-layout.git", "main")
 	if err := r.Clone(context.Background()); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/eagle/internal/project/new.go
+++ b/cmd/eagle/internal/project/new.go
@@ -16,8 +16,8 @@ type Project struct {
 	Name string
 }
 
-// New new a project from remote repo.
-func (p *Project) New(ctx context.Context, dir string, layout string) error {
+// New create a project from remote repo.
+func (p *Project) New(ctx context.Context, dir string, layout string, branch string) error {
 	to := path.Join(dir, p.Name)
 	if _, err := os.Stat(to); !os.IsNotExist(err) {
 		fmt.Printf("🚫 %s already exists\n", p.Name)
@@ -39,11 +39,13 @@ func (p *Project) New(ctx context.Context, dir string, layout string) error {
 		}
 	}
 
-	fmt.Printf("🚀 Creating service %s, layout repo is %s, please wait a moment.\n\n", p.Name, layout)
-	repo := base.NewRepo(layout)
+	fmt.Printf("🚀 Creating service %s, layout repo is %s, branch is %s, please wait a moment.\n\n", p.Name, layout, branch)
+	repo := base.NewRepo(layout, branch)
 	if err := repo.CopyTo(ctx, to, p.Name, []string{".git", ".github"}); err != nil {
 		return err
 	}
+
+	// rename cmd/server to cmd/{p.Name}
 	//e := os.Rename(
 	//	path.Join(to, "cmd", "server"),
 	//	path.Join(to, "cmd", p.Name),

--- a/cmd/eagle/internal/project/project.go
+++ b/cmd/eagle/internal/project/project.go
@@ -21,16 +21,18 @@ var CmdNew = &cobra.Command{
 
 var (
 	repoURL        string
+	branch         string
 	defaultTimeout string
 )
 
 func init() {
-	if repoURL = os.Getenv("eagle_LAYOUT_REPO"); repoURL == "" {
+	if repoURL = os.Getenv("EAGLE_LAYOUT_REPO"); repoURL == "" {
 		repoURL = "https://github.com/go-eagle/eagle-layout.git"
 	}
 
 	defaultTimeout = "60s"
-	CmdNew.Flags().StringVarP(&repoURL, "-repo-url", "r", repoURL, "layout repo")
+	CmdNew.Flags().StringVarP(&repoURL, "repo-url", "r", repoURL, "layout repo")
+	CmdNew.Flags().StringVarP(&branch, "branch", "b", branch, "repo branch name")
 	CmdNew.Flags().StringVarP(&defaultTimeout, "timeout", "t", defaultTimeout, "request timeout time")
 }
 
@@ -65,7 +67,7 @@ func run(cmd *cobra.Command, args []string) {
 	p := &Project{Name: name}
 	done := make(chan error, 1)
 	go func() {
-		done <- p.New(ctx, wd, repoURL)
+		done <- p.New(ctx, wd, repoURL, branch)
 	}()
 
 	select {

--- a/cmd/eagle/main.go
+++ b/cmd/eagle/main.go
@@ -19,7 +19,7 @@ import (
 
 var (
 	// Version is the version of the compiled software.
-	Version = "v0.16.0"
+	Version = "v0.17.0"
 
 	rootCmd = &cobra.Command{
 		Use:     "eagle",


### PR DESCRIPTION
now, you can use a branch name to generate a project, 
for example, in order to a http server only, eg:  eagle new -b feat/http